### PR TITLE
Add Laravel 11 support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,8 +13,8 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest]
-        php: [8.2]
-        laravel: [10.*]
+        php: [8.2, 8.3]
+        laravel: [10.*, 11.*]
         stability: [prefer-stable]
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}

--- a/composer.json
+++ b/composer.json
@@ -9,17 +9,17 @@
     "homepage": "https://github.com/codedor/filament-image-or-video",
     "license": "MIT",
     "require": {
-        "php": "^8.2",
-        "codedor/filament-media-library": "^1.0",
+        "php": "^8.2|^8.3",
+        "codedor/filament-media-library": "dev-feature/laravel-11-support",
         "filament/forms": "^3.2",
-        "illuminate/contracts": "^10.0",
+        "illuminate/contracts": "^10.0|^11.0",
         "spatie/laravel-package-tools": "^1.12"
     },
     "require-dev": {
         "laravel/pint": "^1.0",
-        "nunomaduro/collision": "^7.0",
-        "nunomaduro/larastan": "^2.0",
-        "orchestra/testbench": "^8.0",
+        "nunomaduro/collision": "^7.0|^8.0",
+        "larastan/larastan": "^2.0",
+        "orchestra/testbench": "^8.0|^9.0",
         "pestphp/pest": "^2.0",
         "pestphp/pest-plugin-laravel": "^2.0",
         "phpstan/extension-installer": "^1.1",

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.2|^8.3",
-        "codedor/filament-media-library": "dev-feature/laravel-11-support",
+        "codedor/filament-media-library": "^2.0",
         "filament/forms": "^3.2",
         "illuminate/contracts": "^10.0|^11.0",
         "spatie/laravel-package-tools": "^1.12"

--- a/resources/css/plugin.css
+++ b/resources/css/plugin.css
@@ -1,0 +1,3 @@
+.video-embed-preview .grid.auto-cols-fr.gap-y-2 {
+    aspect-ratio: 16 / 9;
+}

--- a/resources/views/forms/components/video-embed-preview.blade.php
+++ b/resources/views/forms/components/video-embed-preview.blade.php
@@ -23,6 +23,7 @@
     :hint-icon="$getHintIcon()"
     :required="$isRequired()"
     :state-path="$getStatePath()"
+    class="video-embed-preview"
 >
     <div class="border border-gray-300 dark:border-gray-700 rounded-xl overflow-hidden aspect-video w-full h-auto bg-gray-300/30 dark:bg-gray-800/20">
         @if($state && $state['embed_url'])


### PR DESCRIPTION
Requires https://github.com/codedor/filament-media-library/pull/39 to be merged and added to a new release. When that has happened, the version of 'codedor/filament-media-library' has to be set correctly again before merging this PR

Requires a new major version because of spatie/image!