### PR TITLE
FIL001-138: accept a closure for ImageOrVideoUrl attachmentFormats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### What's Changed
+
+* FIL001-138 `ImageOrVideoUrl::make()` accepts a closure for `attachmentFormats`, so the cropper formats can depend on sibling fields. Requires `wotz/filament-media-library` with closure support in `AttachmentInput::allowedFormats()`.
+
 ## v1.2.0 - 2025-11-20
 
 ### What's Changed

--- a/README.md
+++ b/README.md
@@ -25,9 +25,13 @@ php artisan vendor:publish --tag="filament-image-or-video-translations"
 ## Usage
 
 ```php
-$filamentImageOrVideo = new Wotz\FilamentImageOrVideo();
-echo $filamentImageOrVideo->echoPhrase('Hello, Wotz!');
+use App\Formats\Landscape;
+use Wotz\FilamentImageOrVideo\Filament\Components\ImageOrVideoUrl;
+
+ImageOrVideoUrl::make(attachmentFormats: [Landscape::class]);
 ```
+
+`attachmentFormats` also accepts a closure (`fn (Get $get) => [...]`), see the [documentation](./docs/index.md).
 
 ## Documentation
 

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "filament/forms": "^4.0|^5.0",
         "illuminate/contracts": "^12.0|^13.0",
         "spatie/laravel-package-tools": "^1.12",
-        "wotz/filament-media-library": "^4.7"
+        "wotz/filament-media-library": "^4.6"
     },
     "require-dev": {
         "filament/upgrade": "^4.0",

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "filament/forms": "^4.0|^5.0",
         "illuminate/contracts": "^12.0|^13.0",
         "spatie/laravel-package-tools": "^1.12",
-        "wotz/filament-media-library": "^4.0"
+        "wotz/filament-media-library": "^4.7"
     },
     "require-dev": {
         "filament/upgrade": "^4.0",

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,3 +3,31 @@
 ## Introduction
 
 ## Installation
+
+## Usage
+
+```php
+use App\Formats\Landscape;
+use Wotz\FilamentImageOrVideo\Filament\Components\ImageOrVideoUrl;
+
+ImageOrVideoUrl::make(
+    simpleOembed: false,
+    attachmentFormats: [Landscape::class],
+    prefix: '',
+);
+```
+
+`attachmentFormats` is passed to `AttachmentInput::allowedFormats()`. It also accepts a closure, so the cropper formats can follow other fields in the same schema (for example in an Architect block where the rendered format depends on an orientation select):
+
+```php
+use App\Formats\Landscape;
+use App\Formats\Portrait;
+use Filament\Schemas\Components\Utilities\Get;
+
+ImageOrVideoUrl::make(
+    attachmentFormats: fn (Get $get): array => match ($get('orientation')) {
+        'portrait' => [Portrait::class],
+        default => [Landscape::class],
+    },
+);
+```

--- a/src/Filament/Components/ImageOrVideoUrl.php
+++ b/src/Filament/Components/ImageOrVideoUrl.php
@@ -2,16 +2,21 @@
 
 namespace Wotz\FilamentImageOrVideo\Filament\Components;
 
+use Closure;
 use Filament\Forms\Components\Select;
 use Filament\Schemas\Components\Group;
 use Filament\Schemas\Components\Utilities\Get;
 use Wotz\MediaLibrary\Filament\AttachmentInput;
+use Wotz\MediaLibrary\Formats\Format;
 
 class ImageOrVideoUrl
 {
+    /**
+     * @param  array<int, string|Format>|Closure|null  $attachmentFormats
+     */
     public static function make(
         bool $simpleOembed = false,
-        ?array $attachmentFormats = null,
+        null|array|Closure $attachmentFormats = null,
         string $prefix = '',
         bool $noVideo = false
     ): Group {

--- a/tests/Fixtures/ConditionalFormatsComponent.php
+++ b/tests/Fixtures/ConditionalFormatsComponent.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Wotz\FilamentImageOrVideo\Tests\Fixtures;
+
+use Filament\Actions\Concerns\InteractsWithActions;
+use Filament\Actions\Contracts\HasActions;
+use Filament\Forms\Components\Select;
+use Filament\Schemas\Components\Utilities\Get;
+use Filament\Schemas\Concerns\InteractsWithSchemas;
+use Filament\Schemas\Contracts\HasSchemas;
+use Filament\Schemas\Schema;
+use Livewire\Component;
+use Wotz\FilamentImageOrVideo\Filament\Components\ImageOrVideoUrl;
+
+/**
+ * Hosts an ImageOrVideoUrl whose cropper formats follow a sibling select.
+ */
+class ConditionalFormatsComponent extends Component implements HasActions, HasSchemas
+{
+    use InteractsWithActions;
+    use InteractsWithSchemas;
+
+    /** @var array<string, mixed> */
+    public array $data = [];
+
+    public function mount(): void
+    {
+        $this->form->fill(['orientation' => 'landscape', 'image_or_video' => 'image', 'image_id' => null]);
+    }
+
+    public function form(Schema $schema): Schema
+    {
+        return $schema
+            ->components([
+                Select::make('orientation')
+                    ->options(['landscape' => 'Landscape', 'portrait' => 'Portrait'])
+                    ->live(),
+
+                ImageOrVideoUrl::make(
+                    attachmentFormats: fn (Get $get): array => match ($get('orientation')) {
+                        'portrait' => [PortraitFormat::class],
+                        default => [LandscapeFormat::class],
+                    },
+                ),
+            ])
+            ->statePath('data');
+    }
+
+    public function render(): string
+    {
+        return '<div>{{ $this->form }}<x-filament-actions::modals /></div>';
+    }
+}

--- a/tests/Fixtures/LandscapeFormat.php
+++ b/tests/Fixtures/LandscapeFormat.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Wotz\FilamentImageOrVideo\Tests\Fixtures;
+
+use Spatie\Image\Enums\Fit;
+use Wotz\MediaLibrary\Formats\Format;
+use Wotz\MediaLibrary\Formats\Manipulations;
+
+class LandscapeFormat extends Format
+{
+    public function definition(): Manipulations
+    {
+        return $this->manipulations->fit(Fit::Crop, 300, 200);
+    }
+
+    public function registerModelsForFormatter(): void {}
+}

--- a/tests/Fixtures/PortraitFormat.php
+++ b/tests/Fixtures/PortraitFormat.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Wotz\FilamentImageOrVideo\Tests\Fixtures;
+
+use Spatie\Image\Enums\Fit;
+use Wotz\MediaLibrary\Formats\Format;
+use Wotz\MediaLibrary\Formats\Manipulations;
+
+class PortraitFormat extends Format
+{
+    public function definition(): Manipulations
+    {
+        return $this->manipulations->fit(Fit::Crop, 200, 300);
+    }
+
+    public function registerModelsForFormatter(): void {}
+}

--- a/tests/ImageOrVideoUrlTest.php
+++ b/tests/ImageOrVideoUrlTest.php
@@ -1,0 +1,12 @@
+<?php
+
+use Livewire\Livewire;
+use Wotz\FilamentImageOrVideo\Tests\Fixtures\ConditionalFormatsComponent;
+
+it('resolves closure attachment formats against sibling fields', function () {
+    Livewire::test(ConditionalFormatsComponent::class)
+        ->assertSee('300 × 200 px')
+        ->set('data.orientation', 'portrait')
+        ->assertSee('200 × 300 px')
+        ->assertDontSee('300 × 200 px');
+});

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,9 +2,27 @@
 
 namespace Wotz\FilamentImageOrVideo\Tests;
 
+use BladeUI\Heroicons\BladeHeroiconsServiceProvider;
+use BladeUI\Icons\BladeIconsServiceProvider;
+use Filament\Actions\ActionsServiceProvider;
+use Filament\Facades\Filament;
+use Filament\FilamentServiceProvider;
+use Filament\Forms\FormsServiceProvider;
+use Filament\Infolists\InfolistsServiceProvider;
+use Filament\Notifications\NotificationsServiceProvider;
+use Filament\Panel;
+use Filament\Schemas\SchemasServiceProvider;
+use Filament\Support\SupportServiceProvider;
+use Filament\Tables\TablesServiceProvider;
+use Filament\Widgets\WidgetsServiceProvider;
 use Illuminate\Database\Eloquent\Factories\Factory;
+use Livewire\LivewireServiceProvider;
 use Orchestra\Testbench\TestCase as Orchestra;
+use Spatie\Translatable\TranslatableServiceProvider;
 use Wotz\FilamentImageOrVideo\Providers\FilamentImageOrVideoServiceProvider;
+use Wotz\MediaLibrary\Filament\MediaLibraryPlugin;
+use Wotz\MediaLibrary\Providers\MediaLibraryServiceProvider;
+use Wotz\TranslatableTabs\Providers\TranslatableTabsServiceProvider;
 
 class TestCase extends Orchestra
 {
@@ -19,18 +37,42 @@ class TestCase extends Orchestra
 
     protected function getPackageProviders($app)
     {
-        return [
+        // Sorted: Livewire must boot before the Filament providers, otherwise the
+        // component error bag is never initialised and rendering fails.
+        $providers = [
+            LivewireServiceProvider::class,
+            TranslatableTabsServiceProvider::class,
+            ActionsServiceProvider::class,
+            BladeHeroiconsServiceProvider::class,
+            BladeIconsServiceProvider::class,
+            FilamentServiceProvider::class,
+            FormsServiceProvider::class,
+            InfolistsServiceProvider::class,
+            NotificationsServiceProvider::class,
+            SchemasServiceProvider::class,
+            SupportServiceProvider::class,
+            TablesServiceProvider::class,
+            WidgetsServiceProvider::class,
+            TranslatableServiceProvider::class,
+            MediaLibraryServiceProvider::class,
             FilamentImageOrVideoServiceProvider::class,
         ];
+
+        sort($providers);
+
+        return $providers;
     }
 
     public function getEnvironmentSetUp($app)
     {
         config()->set('database.default', 'testing');
 
-        /*
-        $migration = include __DIR__.'/../database/migrations/create_filament-image-or-video_table.php.stub';
-        $migration->up();
-        */
+        $panel = new Panel;
+        $panel
+            ->id('test')
+            ->default(true)
+            ->plugin(MediaLibraryPlugin::make());
+
+        Filament::registerPanel($panel);
     }
 }


### PR DESCRIPTION
Passed straight through to AttachmentInput::allowedFormats(), which accepts closures since filament-media-library 4.7. Lets Architect blocks derive the cropper formats from sibling fields instead of listing every format.